### PR TITLE
fix: openai output val client

### DIFF
--- a/altk/core/llm/providers/openai/openai.py
+++ b/altk/core/llm/providers/openai/openai.py
@@ -307,7 +307,7 @@ class SyncOpenAIClientOutputVal(BaseValidatingOpenAIClient, ValidatingLLMClient)
         self,
         prompt: Union[str, List[Dict[str, str]]],
         schema: Optional[Any] = None,
-        schema_field: Optional[str] = "response_format",
+        schema_field: Optional[str] = None,
         retries: int = 3,
         **kwargs: Any,
     ) -> Union[str, LLMResponse]:
@@ -367,7 +367,7 @@ class AsyncOpenAIClientOutputVal(BaseValidatingOpenAIClient, ValidatingLLMClient
         self,
         prompt: Union[str, List[Dict[str, str]]],
         schema: Optional[Any] = None,
-        schema_field: Optional[str] = "response_format",
+        schema_field: Optional[str] = None,
         retries: int = 3,
         **kwargs: Any,
     ) -> Any:
@@ -491,7 +491,7 @@ class SyncAzureOpenAIClientOutputVal(BaseValidatingOpenAIClient):
         self,
         prompt: Union[str, List[Dict[str, str]]],
         schema: Optional[Any] = None,
-        schema_field: Optional[str] = "response_format",
+        schema_field: Optional[str] = None,
         retries: int = 3,
         **kwargs: Any,
     ) -> Any:
@@ -551,7 +551,7 @@ class AsyncAzureOpenAIClientOutputVal(BaseValidatingOpenAIClient):
         self,
         prompt: Union[str, List[Dict[str, str]]],
         schema: Optional[Any] = None,
-        schema_field: Optional[str] = "response_format",
+        schema_field: Optional[str] = None,
         retries: int = 3,
         **kwargs: Any,
     ) -> Any:


### PR DESCRIPTION
Using fallback response format check instead of the deprecated response_format parameter in their api